### PR TITLE
IND-2152 :construction_worker: build(GHA): Added GHA files to Onboard to CRT

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -17,5 +17,8 @@ project {
 
     # GoReleaser tooling configuration
     ".goreleaser.yml",
+
+    # Release Engineering tooling configuration
+    ".release/*.hcl",
   ]
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,9 @@ env:
   PKG_NAME: "terraform-provider-tfmigrate"
 
 jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
   get-go-version:
     # Inspired by envconsul -- https://github.com/hashicorp/envconsul/blob/bcb270fdc53e1273b3010d51c02fcf2e67d830d0/.github/workflows/build.yml#L18
     name: "Determine Go toolchain version"
@@ -80,6 +83,7 @@ jobs:
     needs:
       - get-go-version
       - set-product-version
+      - test # Ensure the test job has run before building
     runs-on: [ 'self-hosted', 'linux', 'medium' ]
     strategy:
       fail-fast: false # recommended during development
@@ -123,6 +127,7 @@ jobs:
     needs:
       - get-go-version
       - set-product-version
+      - test # Ensure the test job has run before building
     runs-on: macos-latest
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
           PRERELEASE_VERSION: ${{ needs.set-product-version.outputs.product-prerelease-version}}
           METADATA_VERSION: ${{ env.METADATA }}
         with:
-          bin_name: "${{ env.PKG_NAME }}_v${{ needs.set-product-version.outputs.product-version }}_x5"
+          bin_name: "${{ env.PKG_NAME }}_v${{ needs.set-product-version.outputs.product-version }}"
           product_name: ${{ env.PKG_NAME }}
           product_version: ${{ needs.set-product-version.outputs.product-version }}
           go_version: ${{ needs.get-go-version.outputs.go-version }}
@@ -147,7 +147,7 @@ jobs:
           PRERELEASE_VERSION: ${{ needs.set-product-version.outputs.product-prerelease-version}}
           METADATA_VERSION: ${{ env.METADATA }}
         with:
-          bin_name: "${{ env.PKG_NAME }}_v${{ needs.set-product-version.outputs.product-version }}_x5"
+          bin_name: "${{ env.PKG_NAME }}_v${{ needs.set-product-version.outputs.product-version }}"
           product_name: ${{ env.PKG_NAME }}
           product_version: ${{ needs.set-product-version.outputs.product-version }}
           go_version: ${{ needs.get-go-version.outputs.go-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,158 @@
+name: build
+
+# We now default to running this workflow on every push to every branch.
+# This provides fast feedback when build issues occur, so they can be
+# fixed prior to being merged to the main branch.
+#
+# If you want to opt out of this, and only run the build on certain branches
+# please refer to the documentation on branch filtering here:
+#
+#   https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
+#
+#on: [workflow_dispatch, push]
+
+# By dispatch only in development
+on:
+  workflow_dispatch:
+  push:
+    # Sequence of patterns matched against refs/heads
+    branches:
+      # Push events on the main branch
+      - main
+      - release/**
+
+env:
+  PKG_NAME: "terraform-provider-tfmigrate"
+
+jobs:
+  get-go-version:
+    # Inspired by envconsul -- https://github.com/hashicorp/envconsul/blob/bcb270fdc53e1273b3010d51c02fcf2e67d830d0/.github/workflows/build.yml#L18
+    name: "Determine Go toolchain version"
+    runs-on: [ 'self-hosted', 'linux', 'medium' ]
+    outputs:
+      go-version: ${{ steps.get-go-version.outputs.go-version }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Determine Go version
+        id: get-go-version
+        run: |
+          echo "Building with Go $(go env GOVERSION | tr -d 'go')"
+          echo "go-version=$(go env GOVERSION | tr -d 'go')" >> "$GITHUB_OUTPUT"
+
+  set-product-version:
+    runs-on: [ 'self-hosted', 'linux', 'medium' ]
+    outputs:
+      product-version: ${{ steps.set-product-version.outputs.product-version }}
+      product-base-version: ${{ steps.set-product-version.outputs.base-product-version }}
+      product-prerelease-version: ${{ steps.set-product-version.outputs.prerelease-product-version }}
+      product-minor-version: ${{ steps.set-product-version.outputs.minor-product-version }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set Product version
+        id: set-product-version
+        uses: hashicorp/actions-set-product-version@d9b52fb778068099ca4c5e28e1ca0fee2544e114 # v2.0.0
+
+  generate-metadata-file:
+    needs: set-product-version
+    runs-on: [ 'self-hosted', 'linux', 'medium' ]
+    outputs:
+      filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
+    steps:
+      - name: "Checkout directory"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Generate metadata file
+        id: generate-metadata-file
+        uses: hashicorp/actions-generate-metadata@fdbc8803a0e53bcbb912ddeee3808329033d6357 # v1.1.1
+        with:
+          version: ${{ needs.set-product-version.outputs.product-version }}
+          product: ${{ env.PKG_NAME }}
+          repositoryOwner: "hashicorp"
+          repository: "terraform-provider-tfmigrate"
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: metadata.json
+          path: ${{ steps.generate-metadata-file.outputs.filepath }}
+
+  build-other:
+    needs:
+      - get-go-version
+      - set-product-version
+    runs-on: [ 'self-hosted', 'linux', 'medium' ]
+    strategy:
+      fail-fast: false # recommended during development
+      matrix:
+        goos: [ freebsd, windows, linux, darwin ]
+        goarch: [ "386", "amd64", "arm", "arm64" ]
+        exclude:
+          - goos: freebsd
+            goarch: arm64
+          - goos: windows
+            goarch: arm64
+          - goos: windows
+            goarch: arm
+
+    name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: hashicorp/actions-go-build@37358f6098ef21b09542d84a9814ebb843aa4e3e
+        env:
+          CGO_ENABLED: 0
+          BASE_VERSION: ${{ needs.set-product-version.outputs.product-base-version }}
+          PRERELEASE_VERSION: ${{ needs.set-product-version.outputs.product-prerelease-version}}
+          METADATA_VERSION: ${{ env.METADATA }}
+        with:
+          bin_name: "${{ env.PKG_NAME }}_v${{ needs.set-product-version.outputs.product-version }}_x5"
+          product_name: ${{ env.PKG_NAME }}
+          product_version: ${{ needs.set-product-version.outputs.product-version }}
+          go_version: ${{ needs.get-go-version.outputs.go-version }}
+          os: ${{ matrix.goos }}
+          arch: ${{ matrix.goarch }}
+          reproducible: report
+          instructions: |
+            go build \
+              -o "$BIN_PATH" \
+              -trimpath \
+              -buildvcs=false \
+              -ldflags "-s -w -X 'main.Version=${{ needs.set-product-version.outputs.product-version }}'"
+            cp LICENSE "$TARGET_DIR/LICENSE.txt"
+
+  build-darwin:
+    needs:
+      - get-go-version
+      - set-product-version
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        goos: [ darwin ]
+        goarch: [ "amd64", "arm64" ]
+      fail-fast: true
+    name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: hashicorp/actions-go-build@37358f6098ef21b09542d84a9814ebb843aa4e3e
+        env:
+          CGO_ENABLED: 0
+          BASE_VERSION: ${{ needs.set-product-version.outputs.product-base-version }}
+          PRERELEASE_VERSION: ${{ needs.set-product-version.outputs.product-prerelease-version}}
+          METADATA_VERSION: ${{ env.METADATA }}
+        with:
+          bin_name: "${{ env.PKG_NAME }}_v${{ needs.set-product-version.outputs.product-version }}_x5"
+          product_name: ${{ env.PKG_NAME }}
+          product_version: ${{ needs.set-product-version.outputs.product-version }}
+          go_version: ${{ needs.get-go-version.outputs.go-version }}
+          os: ${{ matrix.goos }}
+          arch: ${{ matrix.goarch }}
+          reproducible: report
+          instructions: |
+            go build \
+              -o "$BIN_PATH" \
+              -trimpath \
+              -buildvcs=false \
+              -ldflags "-s -w -X 'main.Version=${{ needs.set-product-version.outputs.product-version }}'"
+            cp LICENSE "$TARGET_DIR/LICENSE.txt"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
   get-go-version:
     # Inspired by envconsul -- https://github.com/hashicorp/envconsul/blob/bcb270fdc53e1273b3010d51c02fcf2e67d830d0/.github/workflows/build.yml#L18
     name: "Determine Go toolchain version"
-    runs-on: [ 'self-hosted', 'linux', 'medium' ]
+    runs-on: ubuntu-latest
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
@@ -46,7 +46,7 @@ jobs:
           echo "go-version=$(go env GOVERSION | tr -d 'go')" >> "$GITHUB_OUTPUT"
 
   set-product-version:
-    runs-on: [ 'self-hosted', 'linux', 'medium' ]
+    runs-on: ubuntu-latest
     outputs:
       product-version: ${{ steps.set-product-version.outputs.product-version }}
       product-base-version: ${{ steps.set-product-version.outputs.base-product-version }}
@@ -60,7 +60,7 @@ jobs:
 
   generate-metadata-file:
     needs: set-product-version
-    runs-on: [ 'self-hosted', 'linux', 'medium' ]
+    runs-on: ubuntu-latest
     outputs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
@@ -84,7 +84,7 @@ jobs:
       - get-go-version
       - set-product-version
       - test # Ensure the test job has run before building
-    runs-on: [ 'self-hosted', 'linux', 'medium' ]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false # recommended during development
       matrix:

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -85,7 +85,4 @@ event "promote-production" {
     on = "always"
   }
 
-  promotion-events {
-  }
-
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -1,0 +1,91 @@
+# Reference: https://github.com/hashicorp/crt-core-helloworld/blob/main/.release/ci.hcl (private repository)
+
+schema = "2"
+
+project "terraform-provider-tfmigrate" {
+  // team is currently unused and has no meaning
+  // but is required to be non-empty by CRT orchestator
+  team = "team-tf-migration"
+
+  slack {
+    notification_channel = "C07FHJ51DQV" // #team-tf-migration-release-announcements
+  }
+
+  github {
+    organization = "hashicorp"
+    repository   = "terraform-provider-tfmigrate"
+    release_branches = ["main", "release/**"]
+  }
+}
+
+event "build" {
+  action "build" {
+    organization = "hashicorp"
+    repository   = "terraform-provider-tfmigrate"
+    workflow     = "build"
+  }
+}
+
+event "prepare" {
+  # `prepare` is the Common Release Tooling (CRT) artifact processing workflow.
+  # It prepares artifacts for potential promotion to staging and production.
+  # For example, it scans and signs artifacts.
+
+  depends = ["build"]
+
+  action "prepare" {
+    organization = "hashicorp"
+    repository   = "crt-workflows-common"
+    workflow     = "prepare"
+    depends = ["build"]
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "trigger-staging" {
+}
+
+event "promote-staging" {
+  action "promote-staging" {
+    organization = "hashicorp"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-staging"
+    depends      = null
+    config       = "oss-release-metadata.hcl"
+  }
+
+  depends = ["trigger-staging"]
+
+  notification {
+    on = "always"
+  }
+
+  promotion-events {
+  }
+}
+
+event "trigger-production" {
+}
+
+event "promote-production" {
+  action "promote-production" {
+    organization = "hashicorp"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-production"
+    depends      = null
+    config       = ""
+  }
+
+  depends = ["trigger-production"]
+
+  notification {
+    on = "always"
+  }
+
+  promotion-events {
+  }
+
+}

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -18,8 +18,12 @@ project "terraform-provider-tfmigrate" {
   }
 }
 
+event "merge  {
+}
+
 event "build" {
   action "build" {
+    depends = ["merge"]
     organization = "hashicorp"
     repository   = "terraform-provider-tfmigrate"
     workflow     = "build"
@@ -61,9 +65,6 @@ event "promote-staging" {
 
   notification {
     on = "always"
-  }
-
-  promotion-events {
   }
 }
 

--- a/.release/oss-release-metadata.hcl
+++ b/.release/oss-release-metadata.hcl
@@ -1,0 +1,4 @@
+url_source_repository         = "https://github.com/hashicorp/terraform-provider-tfmigrate"
+url_project_website           = "https://registry.terraform.io/providers/hashicorp/tfmigrate
+url_license                   = "https://github.com/hashicorp/terraform-provider-tfmigrate/blob/main/LICENSE"
+url_release_notes             = "https://github.com/hashicorp/terraform-provider-tfmigrate/blob/main/CHANGELOG.md"

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,0 +1,11 @@
+# Reference: https://github.com/hashicorp/security-scanner/blob/main/CONFIG.md#binary (private repository)
+
+binary {
+  secrets {
+    all = true
+  }
+  go_modules = true
+  osv        = true
+  oss_index  = false
+  nvd        = false
+}

--- a/.release/terraform-provider-tfmigrate-artifacts.hcl
+++ b/.release/terraform-provider-tfmigrate-artifacts.hcl
@@ -1,0 +1,16 @@
+schema = 1
+artifacts {
+  zip = [
+    "terraform-provider-tfmigrate_${version}_darwin_amd64.zip",
+    "terraform-provider-tfmigrate_${version}_darwin_arm64.zip",
+    "terraform-provider-tfmigrate_${version}_freebsd_386.zip",
+    "terraform-provider-tfmigrate_${version}_freebsd_amd64.zip",
+    "terraform-provider-tfmigrate_${version}_freebsd_arm.zip",
+    "terraform-provider-tfmigrate_${version}_linux_386.zip",
+    "terraform-provider-tfmigrate_${version}_linux_amd64.zip",
+    "terraform-provider-tfmigrate_${version}_linux_arm.zip",
+    "terraform-provider-tfmigrate_${version}_linux_arm64.zip",
+    "terraform-provider-tfmigrate_${version}_windows_386.zip",
+    "terraform-provider-tfmigrate_${version}_windows_amd64.zip",
+  ]
+}


### PR DESCRIPTION
### :hammer_and_wrench: Description

The terraform-provider tf-migrate is released through a release cut process, in which each new version is released with a release cut using go-releaser.

This change adds files to onboard terraform-provider-tf-migrat to CRT.

### :link: External Links

<!-- Jira task (add issue number and uncomment below) -->
- [Jira](https://hashicorp.atlassian.net/browse/IND-2152)
- [Slack-Thread](https://hashicorp.slack.com/archives/C08BJQG7XML/p1738860491437669)
- [CRT onboarding guide for Terraform providers](https://docs.google.com/document/d/1P79cz6OnPxC7jPxpDzf4JthpMMIOy8BI5-O22318eBI/edit?tab=t.0#heading=h.3vky9qg8gy4x)

### :+1: Definition of Done
- All new releases should come from CRT