### PR TITLE
Fix - gitData check before PAT validation

### DIFF
--- a/internal/constants/ui_msg.go
+++ b/internal/constants/ui_msg.go
@@ -49,4 +49,7 @@ For Gitlab, use a personal access token.`
 3. Optionally, you can set TF_MIGRATE_LOG_LEVEL=debug to see debug logs.
    This is not recommended for production environments, as it may expose sensitive information.
 4. If the issue persists, please contact HashiCorp support.`
+
+	// ErrNotGitRepo is the error displayed when the current working directory is not a git repository.
+	ErrNotGitRepo = `fatal: not a git repository (or any of the parent directories): .git`
 )


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
The tool check the following cases during the execute step before validating the git PAT token.

1. Check if the working directory is a git repository or not.
2. Check if the current working directory has a .git folder i.e. the current working directory is the git root repository.
3.  If the Current working directory is a git repo and is the git root, then check if the current working directory is clean.
4. Check the current branch has `hcp-migrate-` prefix.

If all the above cases satisfy then only the tool will validate the TF-GIT-PAT-TOKEN in the execute step.
<!-- Share any information that will help a reviewer without any prior knowledge to build context on why this change was made -->

### :link: External Links

<!-- Jira task (add issue number and uncomment below) -->
<!-- https://hashicorp.atlassian.net/browse/<ISSUE-NUMBER> -->

<!-- Related RFCs, PRs, Slack threads -->

### :+1: Definition of Done

<!-- Check off any testing that has been done. If no testing has been done yet, be sure to let the reviewer know what future testing is planned -->

- [ ] Unit tests added?

<!-- Please uncomment the checkbox below if a database query changed -->
<!-- - [ ] Integration tests added? -->

<!-- Please uncomment checkbox below if e2e tests changed -->
<!-- - [ ] E2E tests run? -->
<!-- If e2e tests were run in integration, include a link to e2e-test GHA run -->
<!-- If the e2e test were run locally, paste the output below -->

<!-- Include any additional details and screenshots to help the reviewer understand what has been tested -->
