### PR TITLE
:bug: fix(git_token): Remove git toekn validation as it is optional

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -134,17 +134,17 @@ func (p *tfmProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		hostname = config.Hostname.ValueString()
 	}
 
-	// Validate configurations
-	if gitPatToken == "" {
-		resp.Diagnostics.AddError(
-			"Missing Authentication Token",
-			"The provider requires the Git PAT token to be configured either as a Terraform variable or an environment variable.",
-		)
-	}
+	// Validate configurations # commenting this because git token validation is not required for now
+	//if gitPatToken == "" {
+	//	resp.Diagnostics.AddError(
+	//		"Missing Authentication Token",
+	//		"The provider requires the Git PAT token to be configured either as a Terraform variable or an environment variable.",
+	//	)
+	//}
 
-	enableTokenValidation, diag := p.enableGitTokenValidation()
-	if diag.HasError() {
-		resp.Diagnostics.Append(diag...)
+	enableTokenValidation, diags := p.enableGitTokenValidation()
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 	if !enableTokenValidation {


### PR DESCRIPTION
### :hammer_and_wrench: Description

We have made [`git_pat_token`](https://registry.terraform.io/providers/hashicorp/tfmigrate/latest/docs#git_pat_token-1) parameter optional but had not removed the validation causing the provider to fail in the absence of the parameter

### :link: External Links

<!-- Jira task (add issue number and uncomment below) -->
<!-- https://hashicorp.atlassian.net/browse/<ISSUE-NUMBER> -->

<!-- Related RFCs, PRs, Slack threads -->

### :+1: Definition of Done

<!-- Check off any testing that has been done. If no testing has been done yet, be sure to let the reviewer know what future testing is planned -->

- [x] Unit tests added?

<!-- Please uncomment the checkbox below if a database query changed -->
<!-- - [ ] Integration tests added? -->

<!-- Please uncomment checkbox below if e2e tests changed -->
<!-- - [ ] E2E tests run? -->
<!-- If e2e tests were run in integration, include a link to e2e-test GHA run -->
<!-- If the e2e test were run locally, paste the output below -->

<!-- Include any additional details and screenshots to help the reviewer understand what has been tested -->
