### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,14 @@
+# This workflow builds the product for all supported platforms and uploads the resulting
+# binaries as Actions artifacts. The workflow also uploads a build metadata file
+# (metadata.json) -- and a Terraform Registry manifest file (terraform-registry-manifest.json).
+#
+# Reference: https://github.com/hashicorp/terraform-provider-crt-example/blob/main/.github/workflows/README.md
+#
+# TODO comments are provided to guide you through customizing this workflow for your provider.
+
 name: build
 
-# We now default to running this workflow on every push to every branch.
+# We default to running this workflow on every push to every branch.
 # This provides fast feedback when build issues occur, so they can be
 # fixed prior to being merged to the main branch.
 #
@@ -9,28 +17,17 @@ name: build
 #
 #   https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
 #
-#on: [workflow_dispatch, push]
-
-# By dispatch only in development
-on:
-  workflow_dispatch:
-  push:
-    # Sequence of patterns matched against refs/heads
-    branches:
-      # Push events on the main branch
-      - main
-      - release/**
+on: [workflow_dispatch, push]
 
 env:
-  PKG_NAME: "terraform-provider-tfmigrate"
+  PKG_NAME: "terraform-provider-crt-example" # TODO: Update with the name of your provider
 
 jobs:
-  test:
-    uses: ./.github/workflows/test.yml
-
+  # Detects the Go toolchain version to use for product builds.
+  #
+  # The implementation is inspired by envconsul -- https://go.hashi.co/get-go-version-example
   get-go-version:
-    # Inspired by envconsul -- https://github.com/hashicorp/envconsul/blob/bcb270fdc53e1273b3010d51c02fcf2e67d830d0/.github/workflows/build.yml#L18
-    name: "Determine Go toolchain version"
+    name: "Detect Go toolchain version"
     runs-on: ubuntu-latest
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
@@ -39,13 +36,19 @@ jobs:
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: 'go.mod'
-      - name: Determine Go version
+      - name: Detect Go version
         id: get-go-version
         run: |
-          echo "Building with Go $(go env GOVERSION | tr -d 'go')"
-          echo "go-version=$(go env GOVERSION | tr -d 'go')" >> "$GITHUB_OUTPUT"
+          version="$(go list -f {{.GoVersion}} -m)"
+          echo "go-version=$version" >> "$GITHUB_OUTPUT"
 
+  # Parses the version/VERSION file. Reference: https://github.com/hashicorp/actions-set-product-version/blob/main/README.md
+  #
+  # > This action should be implemented in product repo `build.yml` files. The action is intended to grab the version
+  # > from the version file at the beginning of the build, then passes those versions (along with metadata, where
+  # > necessary) to any workflow jobs that need version information.
   set-product-version:
+    name: "Parse version file"
     runs-on: ubuntu-latest
     outputs:
       product-version: ${{ steps.set-product-version.outputs.product-version }}
@@ -54,10 +57,13 @@ jobs:
       product-minor-version: ${{ steps.set-product-version.outputs.minor-product-version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Set Product version
+      - name: Set variables
         id: set-product-version
-        uses: hashicorp/actions-set-product-version@d9b52fb778068099ca4c5e28e1ca0fee2544e114 # v2.0.0
+        uses: hashicorp/actions-set-product-version@v2
 
+  # Creates metadata.json file containing build metadata for consumption by CRT workflows.
+  #
+  # Reference: https://github.com/hashicorp/actions-generate-metadata/blob/main/README.md
   generate-metadata-file:
     needs: set-product-version
     runs-on: ubuntu-latest
@@ -68,28 +74,64 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Generate metadata file
         id: generate-metadata-file
-        uses: hashicorp/actions-generate-metadata@fdbc8803a0e53bcbb912ddeee3808329033d6357 # v1.1.1
+        uses: hashicorp/actions-generate-metadata@v1
         with:
           version: ${{ needs.set-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
           repositoryOwner: "hashicorp"
-          repository: "terraform-provider-tfmigrate"
-      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
 
-  build-other:
+  # Uploads an Actions artifact named terraform-registry-manifest.json.zip.
+  #
+  # The artifact contains a single file with a filename that Terraform Registry expects
+  # (example: terraform-provider-crt-example_2.3.6-alpha1_manifest.json). The file contents
+  # are identical to the terraform-registry-manifest.json file in the source repository.
+  upload-terraform-registry-manifest-artifact:
+    needs: set-product-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout directory"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: ${{ env.PKG_NAME }}
+      - name: "Copy manifest from checkout directory to a file with the desired name"
+        id: terraform-registry-manifest
+        run: |
+          name="${{ env.PKG_NAME }}"
+          version="${{ needs.set-product-version.outputs.product-version }}"
+
+          source="${name}/terraform-registry-manifest.json"
+          destination="${name}_${version}_manifest.json"
+
+          cp "$source" "$destination"
+          echo "filename=$destination" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: terraform-registry-manifest.json
+          path: ${{ steps.terraform-registry-manifest.outputs.filename }}
+          if-no-files-found: error
+
+  # Builds the product for all platforms except macOS.
+  #
+  # With `reproducible: report`, this job also reports whether the build is reproducible,
+  # but does not enforce it.
+  #
+  # Reference: https://github.com/hashicorp/actions-go-build/blob/main/README.md
+  build:
     needs:
       - get-go-version
       - set-product-version
-      - test # Ensure the test job has run before building
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false # recommended during development
+      fail-fast: true
+      # TODO: Customize `matrix` for your provider. Compare to existing .goreleaser.yml.
+      # Verify expected Artifacts list for a workflow run.
       matrix:
-        goos: [ freebsd, windows, linux ]
-        goarch: [ "386", "amd64", "arm", "arm64" ]
+        goos: [freebsd, windows, linux, darwin]
+        goarch: ["386", "amd64", "arm", "arm64"]
         exclude:
           - goos: freebsd
             goarch: arm64
@@ -97,67 +139,57 @@ jobs:
             goarch: arm64
           - goos: windows
             goarch: arm
+          - goos: darwin
+            goarch: 386
+          - goos: darwin
+            goarch: arm
 
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: hashicorp/actions-go-build@37358f6098ef21b09542d84a9814ebb843aa4e3e
+      - uses: hashicorp/actions-go-build@v1
+        # TODO: Customize `env` for your provider build. Compare to existing .goreleaser.yml.
         env:
           CGO_ENABLED: 0
           BASE_VERSION: ${{ needs.set-product-version.outputs.product-base-version }}
           PRERELEASE_VERSION: ${{ needs.set-product-version.outputs.product-prerelease-version}}
           METADATA_VERSION: ${{ env.METADATA }}
         with:
-          bin_name: "${{ env.PKG_NAME }}_v${{ needs.set-product-version.outputs.product-version }}"
+          # TODO: Customize `bin_name` for your provider. Compare to existing .goreleaser.yml.
+          # Protocol v6 providers should omit the `_x5` suffix.
+          bin_name: "${{ env.PKG_NAME }}_v${{ needs.set-product-version.outputs.product-version }}_x5"
           product_name: ${{ env.PKG_NAME }}
           product_version: ${{ needs.set-product-version.outputs.product-version }}
           go_version: ${{ needs.get-go-version.outputs.go-version }}
           os: ${{ matrix.goos }}
           arch: ${{ matrix.goarch }}
           reproducible: report
+          # TODO: Customize `go build` flags for your provider. Compare to existing .goreleaser.yml.
+          # TODO: Customize `ldflags` for your provider. Ensure that the import path and name in the -X flag
+          # are correct for your provider.
           instructions: |
             go build \
               -o "$BIN_PATH" \
               -trimpath \
               -buildvcs=false \
-              -ldflags "-s -w -X 'main.Version=${{ needs.set-product-version.outputs.product-version }}'"
+              -ldflags "-s -w -X 'main.version=${{ needs.set-product-version.outputs.product-version }}'"
             cp LICENSE "$TARGET_DIR/LICENSE.txt"
 
-  build-darwin:
+  whats-next:
     needs:
-      - get-go-version
-      - set-product-version
-      - test # Ensure the test job has run before building
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        goos: [ darwin ]
-        goarch: [ "amd64", "arm64" ]
-      fail-fast: true
-    name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
-    env:
-      GOOS: ${{ matrix.goos }}
-      GOARCH: ${{ matrix.goarch }}
+      - build
+      - generate-metadata-file
+      - upload-terraform-registry-manifest-artifact
+    runs-on: ubuntu-latest
+    name: "What's next?"
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: hashicorp/actions-go-build@37358f6098ef21b09542d84a9814ebb843aa4e3e
-        env:
-          CGO_ENABLED: 0
-          BASE_VERSION: ${{ needs.set-product-version.outputs.product-base-version }}
-          PRERELEASE_VERSION: ${{ needs.set-product-version.outputs.product-prerelease-version}}
-          METADATA_VERSION: ${{ env.METADATA }}
-        with:
-          bin_name: "${{ env.PKG_NAME }}_v${{ needs.set-product-version.outputs.product-version }}"
-          product_name: ${{ env.PKG_NAME }}
-          product_version: ${{ needs.set-product-version.outputs.product-version }}
-          go_version: ${{ needs.get-go-version.outputs.go-version }}
-          os: ${{ matrix.goos }}
-          arch: ${{ matrix.goarch }}
-          reproducible: report
-          instructions: |
-            go build \
-              -o "$BIN_PATH" \
-              -trimpath \
-              -buildvcs=false \
-              -ldflags "-s -w -X 'main.Version=${{ needs.set-product-version.outputs.product-version }}'"
-            cp LICENSE "$TARGET_DIR/LICENSE.txt"
+      - name: "Write a helpful summary"
+        run: |
+          github_dot_com="${{ github.server_url }}"
+          owner_with_name="${{ github.repository }}"
+          ref="${{ github.ref }}"
+
+          echo "### What's next?" >> "$GITHUB_STEP_SUMMARY"
+          echo "#### For a release branch (see \`.release/ci.hcl\`)" >> $GITHUB_STEP_SUMMARY
+          echo "After this \`build\` workflow run completes succesfully, you can expect the CRT \`prepare\` workflow to begin momentarily." >> "$GITHUB_STEP_SUMMARY"
+          echo "To find the \`prepare\` workflow run, [view the checks for this commit]($github_dot_com/$owner_with_name/commits/$ref)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
We've made big updates to the build.yml reference example for Terraform providers.

The most critical change is the new
`upload-terraform-registry-manifest-artifact` job. This is necessary for correctness of publishing providers to Terraform Registry.

I open this pull request as a convenient way of notifying your team of this change. In terraform-provider-cloudinit and terraform-provider-null, I have completely replaced the existing build.yml with this new version -- that is the simplest upgrade path.

Review and change the defaults as needed. Follow the TODO comments for step-by-step guidance.
