### PR TITLE
IND-2755, IND-4358 :bug: fix(stack-migration): Replaced stack configuration read with `Stack Configuration List API` from `Stack Configurations Read API`

### DIFF
--- a/docs/resources/stack_migration.md
+++ b/docs/resources/stack_migration.md
@@ -22,8 +22,8 @@ Defines a resource for migrating existing HCP Terraform workspaces to deployment
 
 ### Optional
 
-- `organization` (String) The organization name to which the stack belongs. This must reference an existing organization. Either this attribute or the TFE_ORGANIZATION environment variable is required; if both are set, the attribute value takes precedence.
-- `project` (String) The project name to which the stack belongs. This must reference an existing project. Either this attribute or the TFE_PROJECT environment variable is required; if both are set, the attribute value takes precedence.
+- `organization` (String) The organization name to which the stack belongs. This must reference an existing organization. Either this attribute or the `TFE_ORGANIZATION` environment variable is required; if both are set, the attribute value takes precedence.
+- `project` (String) The project name to which the stack belongs. This must reference an existing project. Either this attribute or the `TFE_PROJECT` environment variable is required; if both are set, the attribute value takes precedence.
 
 ### Read-Only
 

--- a/internal/provider/stack_migration_resource.go
+++ b/internal/provider/stack_migration_resource.go
@@ -58,10 +58,10 @@ const (
 	nameDescription = `The stack name. Must be unique within the organization and project, must be a non-VCS driven stack.`
 
 	// organizationDescription is the Markdown description for the `organization` attribute.
-	organizationDescription = `The organization name to which the stack belongs. This must reference an existing organization. Either this attribute or the TFE_ORGANIZATION environment variable is required; if both are set, the attribute value takes precedence.`
+	organizationDescription = "The organization name to which the stack belongs. This must reference an existing organization. Either this attribute or the `TFE_ORGANIZATION` environment variable is required; if both are set, the attribute value takes precedence."
 
 	// projectDescription is the Markdown description for the `project` attribute.
-	projectDescription = `The project name to which the stack belongs. This must reference an existing project. Either this attribute or the TFE_PROJECT environment variable is required; if both are set, the attribute value takes precedence.`
+	projectDescription = "The project name to which the stack belongs. This must reference an existing project. Either this attribute or the `TFE_PROJECT` environment variable is required; if both are set, the attribute value takes precedence."
 
 	// sourceBundleHashDescription is the Markdown description for the `source_bundle_hash` attribute.
 	sourceBundleHashDescription = `The hash of the configuration files in the directory. This is used to detect changes in the stack configuration files.`


### PR DESCRIPTION
### :hammer_and_wrench: Description

There are API changes in the stacks side due to which now when we read the stack by calling the `/organizations/{organization_name}/stacks` API it does not return the latest configurationId, so we have to call the `/stacks/{stack_id}/stack-configurations`  and take the newest configuration from the top

### :link: External Links

<!-- Jira task (add issue number and uncomment below) -->
https://hashicorp.atlassian.net/browse/IND-4358

<!-- Related RFCs, PRs, Slack threads -->

### :+1: Definition of Done

<!-- Check off any testing that has been done. If no testing has been done yet, be sure to let the reviewer know what future testing is planned -->

- [ ] Unit tests added?

<!-- Please uncomment the checkbox below if a database query changed -->
<!-- - [ ] Integration tests added? -->

<!-- Please uncomment checkbox below if e2e tests changed -->
<!-- - [ ] E2E tests run? -->
<!-- If e2e tests were run in integration, include a link to e2e-test GHA run -->
<!-- If the e2e test were run locally, paste the output below -->

<!-- Include any additional details and screenshots to help the reviewer understand what has been tested -->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
