### PR TITLE
IND-5703 Added Read Action to Stack Migration Resource

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters:
     - staticcheck
     - testifylint
     - unconvert
-    - godot
+#    - godot
   settings:
     depguard:
       rules:

--- a/internal/provider/stack_migration_resource.go
+++ b/internal/provider/stack_migration_resource.go
@@ -829,5 +829,9 @@ func getImportBlockData(body hcl.Body) (bool, error) {
 		return false, fmt.Errorf("failed to get import value: %s", diags.Error())
 	}
 	importValue, diags := attr.Expr.Value(nil)
+
+	if diags.HasErrors() || importValue.IsNull() {
+		return false, fmt.Errorf("failed to get import value: %v", diags.Error())
+	}
 	return importValue.True(), nil
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

This pull request makes several improvements and refactors to the `stack_migration_resource.go` implementation, focusing on the `Read` method, error handling, and code clarity. The most important changes are the completion of the `Read` method to generate migration data and hash, improved error handling and diagnostics, and the disabling of the `ModifyPlan` method. There are also minor configuration changes to the linter setup.

### Stack Migration Resource implementation

* Completed the `Read` method in `stackMigrationResource` to fully generate migration data and migration hash using `migrationHashService`, updating the state accordingly and providing detailed error diagnostics for failures.
* Updated context handling by calling `migrationHashService.UpdateContext(ctx)` in the `Read` method to ensure correct context propagation for migration operations.
* Added a new error constant `errFailedToGetStateValues` for clearer error messaging when state values cannot be retrieved.

### Refactoring and disabling features

* Disabled the `ModifyPlan` method by commenting out its implementation and interface registration, indicating that plan modification logic is not currently supported for this resource. [[1]](diffhunk://#diff-ad884896326e85b10c2645ff94eb21b59d38484a3563cbe192c8d4ac667b17e9R120-R129) [[2]](diffhunk://#diff-ad884896326e85b10c2645ff94eb21b59d38484a3563cbe192c8d4ac667b17e9L616-R740)

### Linter configuration

* Disabled the `godot` linter in `.golangci.yml` by commenting it out, possibly to reduce noise or address compatibility issues.

### :link: External Links

https://hashicorp.atlassian.net/browse/IND-5703

### :+1: Definition of Done

<!-- Check off any testing that has been done. If no testing has been done yet, be sure to let the reviewer know what future testing is planned -->

- [ ] Unit tests added?

<!-- Please uncomment the checkbox below if a database query changed -->
<!-- - [ ] Integration tests added? -->

<!-- Please uncomment checkbox below if e2e tests changed -->
<!-- - [ ] E2E tests run? -->
<!-- If e2e tests were run in integration, include a link to e2e-test GHA run -->
<!-- If the e2e test were run locally, paste the output below -->

<!-- Include any additional details and screenshots to help the reviewer understand what has been tested -->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
