### PR TITLE
Linting fixes

### DIFF
--- a/internal/provider/stack_migration_service.go
+++ b/internal/provider/stack_migration_service.go
@@ -392,7 +392,7 @@ func (r *stackMigrationResource) watchStackConfigurationUntilTerminalStatus(ctx 
 func (r *stackMigrationResource) continueWithStateUploadPostConfigUpload(currentConfigurationId string, currentConfigurationStatus tfe.StackConfigurationStatus) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	//if currentConfigurationStatus == tfe.StackConfigurationStatusConverging || currentConfigurationStatus == tfe.StackConfigurationStatusConverged {
+	// if currentConfigurationStatus == tfe.StackConfigurationStatusConverging || currentConfigurationStatus == tfe.StackConfigurationStatusConverged {
 	//	diags.AddError(
 	//		"Converged Stack Configuration Is Not Supported",
 	//		fmt.Sprintf("The current stack configuration %s has converged. The `tfmigrate_stack_migration` resource does not support state upload for converged stack configurations.", currentConfigurationId))

--- a/internal/util/tfe/tfe.go
+++ b/internal/util/tfe/tfe.go
@@ -30,8 +30,8 @@ import (
 
 var (
 	configConvergenceTimeout = 5 * time.Minute // configConvergenceTimeout defines the maximum time to wait for a stack configuration to converge.
-	stackPlanPollInterval    = 5 * time.Second // stackPlanPollInterval defines the interval at which to poll for stack plans.
-	emptyPollCountThreshold  = 6               // emptyPollCountThreshold defines the number of consecutive empty results before considering the stack plan polling as terminal.
+	// stackPlanPollInterval    = 5 * time.Second // stackPlanPollInterval defines the interval at which to poll for stack plans.
+	// emptyPollCountThreshold = 6 // emptyPollCountThreshold defines the number of consecutive empty results before considering the stack plan polling as terminal.
 )
 
 const (
@@ -67,7 +67,7 @@ type TfeUtil interface {
 	ReadWorkspaceByName(organizationName, workspaceName string, client *tfe.Client) (*tfe.Workspace, error)
 	RerunDeploymentGroup(stackDeploymentGroupId string, deploymentNames []string, client *tfe.Client) error
 	StackConfigurationHasRunningDeploymentGroups(stackConfigurationId string, client *tfe.Client) (bool, error)
-	//StackConfigurationHasRunningPlan(stackConfigurationId string, client *tfe.Client) (bool, error)
+	// StackConfigurationHasRunningPlan(stackConfigurationId string, client *tfe.Client) (bool, error)
 	UpdateContext(ctx context.Context)
 	UploadStackConfigFile(stackId string, configFileDirAbsPath string, client *tfe.Client) (string, error)
 	WatchStackConfigurationUntilTerminalStatus(stackConfigurationId string, client *tfe.Client) (tfe.StackConfigurationStatus, diag.Diagnostics)
@@ -153,7 +153,7 @@ func (u *tfeUtil) NewClient(config *tfe.Config) (*tfe.Client, error) {
 }
 
 // HandleConvergingStatus handles the converging status of a stack configuration.
-//func (u *tfeUtil) HandleConvergingStatus(currentConfigurationId string, client *tfe.Client) string {
+// func (u *tfeUtil) HandleConvergingStatus(currentConfigurationId string, client *tfe.Client) string {
 //	tflog.Debug(u.ctx, fmt.Sprintf("Handling converging status for stack configuration ID: %s", currentConfigurationId))
 //	ctx, cancel := context.WithTimeout(u.ctx, configConvergenceTimeout)
 //	defer cancel()
@@ -582,7 +582,7 @@ func (u *tfeUtil) StackConfigurationHasRunningDeploymentGroups(stackConfiguratio
 }
 
 // StackConfigurationHasRunningPlan checks if the stack configuration has any running plans.
-//func (u *tfeUtil) StackConfigurationHasRunningPlan(stackConfigurationId string, client *tfe.Client) (bool, error) {
+// func (u *tfeUtil) StackConfigurationHasRunningPlan(stackConfigurationId string, client *tfe.Client) (bool, error) {
 //	stackPlanOpts := &tfe.StackPlansListOptions{
 //		Status: tfe.StackPlansStatusFilterRunning,
 //	}
@@ -692,10 +692,10 @@ func (u *tfeUtil) WatchStackConfigurationUntilTerminalStatus(stackConfigurationI
 func (u *tfeUtil) handleCurrentConfigurationStatus(stackConfigurationID string, currentStatus tfe.StackConfigurationStatus) (string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	switch currentStatus {
-	//case tfe.StackConfigurationStatusConverged:
+	// case tfe.StackConfigurationStatusConverged:
 	//	tflog.Info(u.ctx, fmt.Sprintf("Stack configuration %s has converged", stackConfigurationID))
 	//	return currentStatus.String(), diags
-	//case tfe.StackConfigurationStatusConverging:
+	// case tfe.StackConfigurationStatusConverging:
 	//	tflog.Debug(u.ctx, fmt.Sprintf("Stack configuration %s is converging", stackConfigurationID))
 	//	return currentStatus.String(), diags
 	case tfe.StackConfigurationStatusErrored:
@@ -761,7 +761,7 @@ func (u *tfeUtil) handleTfeClientResourceReadError(err error) error {
 }
 
 // pollConvergingConfigurationsForRunningStackPlans polls the TFE API to fetch running stack plans associated with a converging stack configuration.
-//func pollConvergingConfigurationsForRunningStackPlans(ctx context.Context, convergingStackConfigurationId string, tfeClient *tfe.Client) <-chan PollResult { // nosonar
+// func pollConvergingConfigurationsForRunningStackPlans(ctx context.Context, convergingStackConfigurationId string, tfeClient *tfe.Client) <-chan PollResult { // nosonar
 //	resultChan := make(chan PollResult)
 //	stackPlanOpts := &tfe.StackPlansListOptions{
 //		Status: tfe.StackPlansStatusFilterRunning,


### PR DESCRIPTION
### :hammer_and_wrench: Description

This pull request makes a minor change by commenting out the `stackPlanPollInterval` and `emptyPollCountThreshold` variable declarations in `internal/util/tfe/tfe.go`. No functional code is added or removed; these variables are now inactive in the codebase.



### :link: External Links

<!-- Jira task (add issue number and uncomment below) -->
<!-- https://hashicorp.atlassian.net/browse/<ISSUE-NUMBER> -->

<!-- Related RFCs, PRs, Slack threads -->

### :+1: Definition of Done

<!-- Check off any testing that has been done. If no testing has been done yet, be sure to let the reviewer know what future testing is planned -->

- [x] Unit tests added?

<!-- Please uncomment the checkbox below if a database query changed -->
<!-- - [ ] Integration tests added? -->

<!-- Please uncomment checkbox below if e2e tests changed -->
<!-- - [ ] E2E tests run? -->
<!-- If e2e tests were run in integration, include a link to e2e-test GHA run -->
<!-- If the e2e test were run locally, paste the output below -->

<!-- Include any additional details and screenshots to help the reviewer understand what has been tested -->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
