### PR TITLE
Fix Bug when there are no deployment runs after the configuration upload for stacks migration

### DIFF
--- a/internal/util/tfe/tfe.go
+++ b/internal/util/tfe/tfe.go
@@ -381,7 +381,16 @@ func (u *tfeUtil) ReadLatestDeploymentRunByDeploymentName(stackId string, deploy
 		return nil, err
 	}
 
-	deploymentGroupId := latestDeploymentRun.Relationships.StackDeploymentGroup.Data.Id
+	deploymentGroupId := ""
+	if latestDeploymentRun != nil && latestDeploymentRun.Relationships != nil &&
+		latestDeploymentRun.Relationships.StackDeploymentGroup != nil &&
+		latestDeploymentRun.Relationships.StackDeploymentGroup.Data != nil &&
+		latestDeploymentRun.Relationships.StackDeploymentGroup.Data.Id != "" {
+		deploymentGroupId = latestDeploymentRun.Relationships.StackDeploymentGroup.Data.Id
+	} else {
+		tflog.Error(u.ctx, fmt.Sprintf("No deployment group found for latest deployment %s", deploymentName))
+		return nil, fmt.Errorf("no deployment group found for latest deployment run ID %s", deploymentName)
+	}
 
 	// Read the stack deployment group to get the latest deployment groupId for the stack deployment run
 	stackDeploymentGroup, err := tfeClient.StackDeploymentGroups.Read(u.ctx, deploymentGroupId)


### PR DESCRIPTION
### :hammer_and_wrench: Description

This pull request prepares the project for the release candidate of version 2.0.0, focusing on reliability improvements for HCP Terraform Stacks migration and error handling in deployment utilities. The changes update versioning, document the release, and strengthen error checking in deployment code.

Release preparation:

* Updated the version to `2.0.0-rc1` in `version/VERSION` to mark the release candidate.
* Added a new section to `CHANGELOG.md` announcing Release Candidate 1 for HCP Terraform Stacks Migration, including notes about improved reliability for the `tfmigrate_stack_migration` resource.

Reliability and error handling improvements:

* Enhanced error checking in `internal/util/tfe/tfe.go`: the `ReadLatestDeploymentRunByDeploymentName` function now verifies the existence of a deployment group and logs an error if missing, returning a clear error message.

### :link: External Links

<!-- Jira task (add issue number and uncomment below) -->
<!-- https://hashicorp.atlassian.net/browse/<ISSUE-NUMBER> -->

<!-- Related RFCs, PRs, Slack threads -->

### :+1: Definition of Done

<!-- Check off any testing that has been done. If no testing has been done yet, be sure to let the reviewer know what future testing is planned -->

- [x] Unit tests added?

<!-- Please uncomment the checkbox below if a database query changed -->
<!-- - [ ] Integration tests added? -->

<!-- Please uncomment checkbox below if e2e tests changed -->
<!-- - [ ] E2E tests run? -->
<!-- If e2e tests were run in integration, include a link to e2e-test GHA run -->
<!-- If the e2e test were run locally, paste the output below -->

<!-- Include any additional details and screenshots to help the reviewer understand what has been tested -->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
